### PR TITLE
Release 0.1.2: cargo-binstall support & install UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-02-09
+
+### Added
+
+- `cargo binstall fossil-mcp` support via `[package.metadata.binstall]` in Cargo.toml
+- Per-target binary overrides for all 6 release platforms (Linux glibc/musl/aarch64, macOS Intel/Apple Silicon, Windows)
+- `cargo-binstall` install section in README
+
+### Changed
+
+- Moved VS Code / Cursor one-click install badges from top of README into MCP Server Setup section for clearer install flow
+- Fixed hardcoded `0.1.0` download URLs in README to use version-less `/releases/latest/download/` URLs
+
 ## [0.1.1] - 2025-02-07
 
 ### Added
@@ -42,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SARIF, JSON, and text output formats
 - Configuration via `.fossil.toml`
 
+[0.1.2]: https://github.com/yfedoseev/fossil-mcp/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/yfedoseev/fossil-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/yfedoseev/fossil-mcp/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fossil-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -123,3 +123,27 @@ opt-level = 0
 
 [profile.test]
 opt-level = 1
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-x86_64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-x86_64-musl.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-aarch64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-x86_64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-aarch64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-windows-x86_64.zip"
+pkg-fmt = "zip"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Static analysis that finds the mess vibe coding leaves behind — dead code, dup
 [![Crates.io](https://img.shields.io/crates/v/fossil-mcp.svg)](https://crates.io/crates/fossil-mcp)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
 
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=fossil&config=%7B%22command%22%3A%22fossil-mcp%22%7D)
-[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=fossil&config=%7B%22command%22%3A%22fossil-mcp%22%7D&quality=insiders)
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=fossil&config=eyJjb21tYW5kIjoiZm9zc2lsLW1jcCJ9)
-
 ---
 
 ## The Problem
@@ -76,15 +72,15 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-macos-aarch64-0.1.0.tar.gz | tar xz
+curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-macos-aarch64.tar.gz | tar xz
 mv fossil-mcp /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-macos-x86_64-0.1.0.tar.gz | tar xz
+curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-macos-x86_64.tar.gz | tar xz
 mv fossil-mcp /usr/local/bin/
 
 # Linux (x86_64)
-curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-linux-x86_64-0.1.0.tar.gz | tar xz
+curl -L https://github.com/yfedoseev/fossil-mcp/releases/latest/download/fossil-mcp-linux-x86_64.tar.gz | tar xz
 mv fossil-mcp ~/.local/bin/
 ```
 
@@ -96,6 +92,14 @@ mv fossil-mcp ~/.local/bin/
 | macOS | Intel | `fossil-mcp-macos-x86_64` |
 | macOS | Apple Silicon | `fossil-mcp-macos-aarch64` |
 | Windows | x86_64 | `fossil-mcp-windows-x86_64` |
+
+### cargo-binstall
+
+If you have [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), it downloads pre-built binaries instead of compiling from source:
+
+```bash
+cargo binstall fossil-mcp
+```
 
 ### From crates.io
 
@@ -115,9 +119,19 @@ cargo build --release
 
 The binary is at `./target/release/fossil-mcp`.
 
+### Updating
+
+```bash
+fossil-mcp update
+```
+
 ---
 
 ## MCP Server Setup
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=fossil&config=%7B%22command%22%3A%22fossil-mcp%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=fossil&config=%7B%22command%22%3A%22fossil-mcp%22%7D&quality=insiders)
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=fossil&config=eyJjb21tYW5kIjoiZm9zc2lsLW1jcCJ9)
 
 Fossil runs as an MCP server by default — just run `fossil-mcp` with no arguments. Connect it to your AI coding tool:
 


### PR DESCRIPTION
## Summary

- Add `cargo binstall fossil-mcp` support via `[package.metadata.binstall]` with per-target overrides for all 6 release platforms
- Fix hardcoded `0.1.0` download URLs in README to use version-less `/releases/latest/download/` URLs
- Move VS Code / Cursor one-click install badges from top of README into MCP Server Setup section (they require the binary to be installed first)
- Add cargo-binstall and self-update sections to README
- Bump version to 0.1.2

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — all 777 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] After merge + release: `cargo binstall fossil-mcp` downloads binary instead of compiling